### PR TITLE
Fix: Update ClearArt mapping to 'Art' and add missing Gunicorn dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN mkdir -p /app/data /app/output
 
 EXPOSE 1280
 
-CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:1280", "app:app"]
+# Change the CMD line to include the timeout - needed for large collections
+CMD ["gunicorn", "--bind", "0.0.0.0:1280", "--timeout", "300", "app:app"]

--- a/generate_html.py
+++ b/generate_html.py
@@ -47,7 +47,7 @@ PIXELFIN_LOGO_BASE64 = _load_pixelfin_logo_base64()
 
 IMAGE_TYPES_MAP = {
 	"p": "Primary",
-	"c": "ClearArt",
+	"c": "Art",
 	"bd": "Backdrop",
 	"bn": "Banner",
 	"b": "Box",
@@ -67,7 +67,7 @@ DEFAULT_ZIP_BASENAMES = {
 	"p": "cover",
 	"t": "thumbnail",
 	"bd": "backdrop",
-	"c": "clearart",
+	"c": "art",
 	"bn": "banner",
 	"b": "box",
 	"br": "boxrear",
@@ -76,7 +76,7 @@ DEFAULT_ZIP_BASENAMES = {
 	"m": "menu",
 }
 
-_DEFAULT_TIMEOUT = (10, 30)
+_DEFAULT_TIMEOUT = (10, 120)
 _session: Optional[requests.Session] = None
 _SAFE_NAME_RE = re.compile(r'[\\/:*?"<>|\r\n]+')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 Pillow
 Flask
+gunicorn


### PR DESCRIPTION
Fixed the issue where ClearArt images weren't being pulled from Jellyfin by updating the mapping to 'Art' in generate_html.py.

Added gunicorn to requirements.txt to prevent the Docker container from crashing on startup with an 'executable not found' error.

Note: Increased Gunicorn timeout might be needed for users with large libraries (tested with 2500+ items).